### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ How It Works?
 
 - Receiving Email:
 
-  You can easily get the receving emails from different vendors like sendgrid, aws ses, mailgun, by configuring and veririfying your website records in the specified email vendors like SES.
+  You can easily get the receiving emails from different vendors like sendgrid, aws ses, mailgun, by configuring and verifying your website records in the specified email vendors like SES.
 
   Now It supports only ses for receiving emails, we'll release a version to support sendgrid, mailgun.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@ django-email-gateway's documentation:
 Introduction:
 =============
 
-django-email-gateway is used for sending mails from your verified domains and verified emails with less cost. We can also use django-email-gateway for receive messages and deliver them to an Amazon S3 bucket in an enctypted format, call your custom code via an AWS Lambda function, or publish notifications to Amazon SNS to process the response.
+django-email-gateway is used for sending mails from your verified domains and verified emails with less cost. We can also use django-email-gateway for receive messages and deliver them to an Amazon S3 bucket in an encrypted format, call your custom code via an AWS Lambda function, or publish notifications to Amazon SNS to process the response.
 
 Source Code is available in Micropyramid Repository(https://github.com/MicroPyramid/django-email-gateway).
 
@@ -51,10 +51,10 @@ We need to verify email address and domains to confirm that we are using those d
 
 Login into AWS console if you have already AWS account or signup at https://portal.aws.amazon.com/gp/aws/developer/registration/index.html
 
-1. For each region, we need to verify the domain seperately.
+1. For each region, we need to verify the domain separately.
 2. In aws ses/domains panel, you can view all the domains with their verification status, bounce, compaint sns topic, dkim, mail from domain details
 3. By clicking on Verify a New Domain, a popup will be appeared to create new domain along with dkim settings
-4. After creation of new domain, a popup will be appeared by displaying a txt, cname, mx records of a repsective domain. You need to add these reocords your domains dns server
+4. After creation of new domain, a popup will be appeared by displaying a txt, cname, mx records of a respective domain. You need to add these reocords your domains dns server
 5. After adding these details, you can check your domain verification status
 6. If your domain successfully verified, then all your emails with respective domain, sub domains will also be verified.
 
@@ -69,8 +69,8 @@ Verifying Email Addresses
 Receiving Email
 =================
 1. In aws ses Email Receiving, choose Rule Sets. then in content panel choose Create a Receipt Rule.
-2. In the add action menu, choose s3, then you need to select/create a bucket to store all encypted receiving emails content.
-3. To recieve sns notifications, add another action of sns. Here you need to create/select a topic to process the receiving mail message content.
+2. In the add action menu, choose s3, then you need to select/create a bucket to store all encrypted receiving emails content.
+3. To receive sns notifications, add another action of sns. Here you need to create/select a topic to process the receiving mail message content.
 4. Then in Rule Details page, give the rule name, create the rule.
 5. In AWS-SNS services, for the topic which you have created/selected in active receipt rule set, you need to add your subscription request which may either email, AWS SQS, HTTP or HTTPS.
 6. For the http or https, you need to specify the endpoint(Your application URL to receive email content), SNS will send the receiving email content to specified url.


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/source/index.rst

Fixes:
- Should read `verifying` rather than `veririfying`.
- Should read `separately` rather than `seperately`.
- Should read `respective` rather than `repsective`.
- Should read `receiving` rather than `receving`.
- Should read `receive` rather than `recieve`.
- Should read `encrypted` rather than `encypted`.
- Should read `encrypted` rather than `enctypted`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md